### PR TITLE
feat: Add retry decorator

### DIFF
--- a/src/MetricsFactory.php
+++ b/src/MetricsFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spiral\RoadRunner\Metrics;
+
+use Spiral\Goridge\RPC\RPCInterface;
+
+class MetricsFactory
+{
+    public function create(RPCInterface $rpc, MetricsOptions $options): MetricsInterface
+    {
+        return new RetryMetrics(
+            new Metrics($rpc),
+            $options->retryAttempts,
+            $options->retrySleepMicroseconds,
+        );
+    }
+}

--- a/src/MetricsOptions.php
+++ b/src/MetricsOptions.php
@@ -4,6 +4,10 @@ namespace Spiral\RoadRunner\Metrics;
 
 class MetricsOptions
 {
+    /**
+     * @param int<0, max> $retryAttempts
+     * @param int<0, max> $retrySleepMicroseconds
+     */
     public function __construct(
         public readonly int $retryAttempts = 3,
         public readonly int $retrySleepMicroseconds = 50,

--- a/src/MetricsOptions.php
+++ b/src/MetricsOptions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spiral\RoadRunner\Metrics;
+
+class MetricsOptions
+{
+    public function __construct(
+        public readonly int $retryAttempts = 3,
+        public readonly int $retrySleepMicroseconds = 50,
+    ) {
+    }
+}

--- a/src/RetryMetrics.php
+++ b/src/RetryMetrics.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Spiral\RoadRunner\Metrics;
+
+use Spiral\RoadRunner\Metrics\Exception\MetricsException;
+
+class RetryMetrics implements MetricsInterface
+{
+    /**
+     * @param int<0, max> $retryAttempts
+     * @param int<0, max> $retrySleepMicroseconds
+     */
+    public function __construct(
+        private readonly MetricsInterface $metrics,
+        private readonly int $retryAttempts,
+        private readonly int $retrySleepMicroseconds,
+    ) {
+    }
+
+    public function add(string $name, float $value, array $labels = []): void
+    {
+        $this->retry(fn () => $this->metrics->add($name, $value, $labels));
+    }
+
+    public function sub(string $name, float $value, array $labels = []): void
+    {
+        $this->retry(fn () => $this->metrics->sub($name, $value, $labels));
+    }
+
+    public function observe(string $name, float $value, array $labels = []): void
+    {
+        $this->retry(fn () => $this->metrics->observe($name, $value, $labels));
+    }
+
+    public function set(string $name, float $value, array $labels = []): void
+    {
+        $this->retry(fn () => $this->metrics->set($name, $value, $labels));
+    }
+
+    public function declare(string $name, CollectorInterface $collector): void
+    {
+        $this->retry(fn () => $this->metrics->declare($name, $collector));
+    }
+
+    public function unregister(string $name): void
+    {
+        $this->retry(fn () => $this->metrics->unregister($name));
+    }
+
+    private function retry(callable $request): void
+    {
+        // 1 + retryAttempts
+        $attempts = -1;
+
+        do {
+            try {
+                $request();
+
+                return;
+            } catch (MetricsException $e) {
+                if (++$attempts === $this->retryAttempts) {
+                    throw $e;
+                }
+            }
+
+            usleep($this->retrySleepMicroseconds);
+        } while ($attempts < $this->retryAttempts);
+    }
+}

--- a/tests/Unit/RetryMetricsTest.php
+++ b/tests/Unit/RetryMetricsTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Spiral\RoadRunner\Metrics\Tests\Unit;
+
+use PHPUnit\Framework\MockObject\Rule\InvokedCount;
+use PHPUnit\Framework\TestCase;
+use Spiral\RoadRunner\Metrics\Collector;
+use Spiral\RoadRunner\Metrics\Exception\MetricsException;
+use Spiral\RoadRunner\Metrics\MetricsInterface;
+use Spiral\RoadRunner\Metrics\RetryMetrics;
+
+final class RetryMetricsTest extends TestCase
+{
+    public function testAddWithMetricsException(): void
+    {
+        $metrics = $this->createMetricsMock('add', 4, 4);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        self::expectException(MetricsException::class);
+
+        $retryMetrics->add('counter', 1);
+    }
+
+    public function testAddOk(): void
+    {
+        $metrics = $this->createMetricsMock('add', 4, 3);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        $retryMetrics->add('counter', 1);
+    }
+
+    public function testSubWithMetricsException(): void
+    {
+        $metrics = $this->createMetricsMock('sub', 4, 4);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        self::expectException(MetricsException::class);
+
+        $retryMetrics->sub('counter', 1);
+    }
+
+    public function testSubOk(): void
+    {
+        $metrics = $this->createMetricsMock('sub', 4, 3);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        $retryMetrics->sub('counter', 1);
+    }
+
+    public function testObserveWithMetricsException(): void
+    {
+        $metrics = $this->createMetricsMock('observe', 4, 4);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        self::expectException(MetricsException::class);
+
+        $retryMetrics->observe('counter', 1);
+    }
+
+    public function testObserveOk(): void
+    {
+        $metrics = $this->createMetricsMock('observe', 4, 3);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        $retryMetrics->observe('counter', 1);
+    }
+
+    public function testSetWithMetricsException(): void
+    {
+        $metrics = $this->createMetricsMock('set', 4, 4);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        self::expectException(MetricsException::class);
+
+        $retryMetrics->set('counter', 1);
+    }
+
+    public function testSetOk(): void
+    {
+        $metrics = $this->createMetricsMock('set', 4, 3);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        $retryMetrics->set('counter', 1);
+    }
+
+    public function testDeclareWithMetricsException(): void
+    {
+        $metrics = $this->createMetricsMock('declare', 4, 4);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        self::expectException(MetricsException::class);
+
+        $retryMetrics->declare('counter', Collector::counter());
+    }
+
+    public function testDeclareOk(): void
+    {
+        $metrics = $this->createMetricsMock('declare', 4, 3);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        $retryMetrics->declare('counter', Collector::counter());
+    }
+
+    public function testUnregisterWithMetricsException(): void
+    {
+        $metrics = $this->createMetricsMock('unregister', 4, 4);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        self::expectException(MetricsException::class);
+
+        $retryMetrics->unregister('counter');
+    }
+
+    public function testUnregisterOk(): void
+    {
+        $metrics = $this->createMetricsMock('unregister', 4, 3);
+
+        $retryMetrics = new RetryMetrics(
+            $metrics,
+            3,
+            1,
+        );
+
+        $retryMetrics->unregister('counter');
+    }
+
+    private function createMetricsMock(string $method, int $expectedCalls, int $exceptions): MetricsInterface
+    {
+        $metrics = $this->createMock(MetricsInterface::class);
+
+        $metrics
+            ->expects(new InvokedCount($expectedCalls))
+            ->method($method)
+            ->willReturnOnConsecutiveCalls(...array_fill(
+                0,
+                $exceptions,
+                $this->throwException(new MetricsException()),
+            ));
+
+        return $metrics;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

This PR adds a decorator to send requests to the **metrics** service using **retry** when the RPC request fails.

New parameters for retry decorator:

| Parameter              | Default value |
|------------------------|---------------|
| retryAttempts          | 3             |
| retrySleepMicroseconds | 50            |

**Client code example**

```php
$factory = new \Spiral\RoadRunner\Metrics\MetricsFactory();

$metrics = $factory->create(\Spiral\Goridge\RPC\RPC::create('dsn'), new \Spiral\RoadRunner\Metrics\MetricsOptions(
    retryAttempts: 3,
    retrySleepMicroseconds: 50,
));
```
