### PR TITLE
feat: Add suppress exceptions decorator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "psr/log": "^3.0",
         "spiral/goridge": "^4.0",
         "spiral/roadrunner": "^2023.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "psr/log": "^3.0",
+        "psr/log": ">=2.0",
         "spiral/goridge": "^4.0",
         "spiral/roadrunner": "^2023.1"
     },

--- a/src/SuppressExceptionsMetrics.php
+++ b/src/SuppressExceptionsMetrics.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Spiral\RoadRunner\Metrics;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Spiral\RoadRunner\Metrics\Exception\MetricsException;
+
+class SuppressExceptionsMetrics implements MetricsInterface
+{
+    public function __construct(
+        private readonly MetricsInterface $metrics,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function add(string $name, float $value, array $labels = []): void
+    {
+        try {
+            $this->metrics->add($name, $value, $labels);
+        } catch (MetricsException $e) {
+            $this->logger->warning(sprintf('[Metrics] Operation "Add" was failed: %s', $e->getMessage()));
+        }
+    }
+
+    public function sub(string $name, float $value, array $labels = []): void
+    {
+        try {
+            $this->metrics->sub($name, $value, $labels);
+        } catch (MetricsException $e) {
+            $this->logger->warning(sprintf('[Metrics] Operation "Sub" was failed: %s', $e->getMessage()));
+        }
+    }
+
+    public function observe(string $name, float $value, array $labels = []): void
+    {
+        try {
+            $this->metrics->observe($name, $value, $labels);
+        } catch (MetricsException $e) {
+            $this->logger->warning(sprintf('[Metrics] Operation "Observe" was failed: %s', $e->getMessage()));
+        }
+    }
+
+    public function set(string $name, float $value, array $labels = []): void
+    {
+        try {
+            $this->metrics->set($name, $value, $labels);
+        } catch (MetricsException $e) {
+            $this->logger->warning(sprintf('[Metrics] Operation "Set" was failed: %s', $e->getMessage()));
+        }
+    }
+
+    public function declare(string $name, CollectorInterface $collector): void
+    {
+        try {
+            $this->metrics->declare($name, $collector);
+        } catch (MetricsException $e) {
+            $this->logger->warning(sprintf('[Metrics] Operation "Declare" was failed: %s', $e->getMessage()));
+        }
+    }
+
+    public function unregister(string $name): void
+    {
+        try {
+            $this->metrics->unregister($name);
+        } catch (MetricsException $e) {
+            $this->logger->warning(sprintf('[Metrics] Operation "Unregister" was failed: %s', $e->getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

This request adds a decorator to suppress errors when making requests to the **metrics** service and logging them.

**Use case**

For example, metrics can be involved in payment transactions. The loss of a metric is less critical than the loss of a transaction, so the drop in the metric can be suppressed.

**Client code example**

```php
$metrics = new \Spiral\RoadRunner\Metrics\SuppressExceptionsMetrics(
    new \Spiral\RoadRunner\Metrics\Metrics(\Spiral\Goridge\RPC\RPC::create('dsn'),
));
```
