### PR TITLE
feat: Add support SuppressExceptionsMetrics for MetricsFactory

### DIFF
--- a/src/MetricsFactory.php
+++ b/src/MetricsFactory.php
@@ -2,16 +2,29 @@
 
 namespace Spiral\RoadRunner\Metrics;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Spiral\Goridge\RPC\RPCInterface;
 
 class MetricsFactory
 {
+    public function __construct(
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
     public function create(RPCInterface $rpc, MetricsOptions $options): MetricsInterface
     {
-        return new RetryMetrics(
+        $metrics = new RetryMetrics(
             new Metrics($rpc),
             $options->retryAttempts,
             $options->retrySleepMicroseconds,
         );
+
+        if ($options->suppressExceptions) {
+            $metrics = new SuppressExceptionsMetrics($metrics, $this->logger);
+        }
+
+        return $metrics;
     }
 }

--- a/src/MetricsOptions.php
+++ b/src/MetricsOptions.php
@@ -11,6 +11,7 @@ class MetricsOptions
     public function __construct(
         public readonly int $retryAttempts = 3,
         public readonly int $retrySleepMicroseconds = 50,
+        public readonly bool $suppressExceptions = false,
     ) {
     }
 }

--- a/tests/Unit/MetricsFactoryTest.php
+++ b/tests/Unit/MetricsFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spiral\RoadRunner\Metrics\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Goridge\RPC\RPC;
+use Spiral\Goridge\RPC\RPCInterface;
+use Spiral\RoadRunner\Metrics\MetricsFactory;
+use Spiral\RoadRunner\Metrics\MetricsOptions;
+use Spiral\RoadRunner\Metrics\RetryMetrics;
+use Spiral\RoadRunner\Metrics\SuppressExceptionsMetrics;
+
+final class MetricsFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider providerForTestCreate
+     */
+    public function testCreate(MetricsOptions $options, string $expectedClass): void
+    {
+        $factory = new MetricsFactory();
+
+        $rpc = $this->createMock(RPCInterface::class);
+        $rpc->expects($this->once())->method('withServicePrefix')
+            ->with('metrics')
+            ->willReturn($rpc);
+
+        self::assertInstanceOf($expectedClass, $factory->create($rpc, $options));
+    }
+
+    public static function providerForTestCreate(): array
+    {
+        return [
+            'create RetryMetrics' => [
+                'options' => new MetricsOptions(),
+                'expectedClass' => RetryMetrics::class,
+            ],
+            'create SuppressExceptionsMetrics' => [
+                'options' => new MetricsOptions(suppressExceptions: true),
+                'expectedClass' => SuppressExceptionsMetrics::class,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->

In order not to create a puzzle for the user when choosing the order of decorators, I suggest allowing everything at the _MetricsFactory_ level.

## Use cases

### Create only RetryMetrics

Created only **RetryMetrics** because the **suppressExceptions** option defaults to **false**

```php
$factory = new \Spiral\RoadRunner\Metrics\MetricsFactory();

var_dump(get_class($factory->create(
    \Spiral\Goridge\RPC\RPC::create('dsn'),
    new \Spiral\RoadRunner\Metrics\MetricsOptions(),
))); // \Spiral\RoadRunner\Metrics\RetryMetrics
```

### Create SuppressExceptionsMetrics with RetryMetrics

**RetryMetrics** are always created because **retry** is good practice.

```php
$factory = new \Spiral\RoadRunner\Metrics\MetricsFactory();

var_dump(get_class($factory->create(
    \Spiral\Goridge\RPC\RPC::create('dsn'),
    new \Spiral\RoadRunner\Metrics\MetricsOptions(
        suppressExceptions: true,
    ),
))); // \Spiral\RoadRunner\Metrics\SuppressExceptionsMetrics
```
