### PR TITLE
Adds summary metric type

### DIFF
--- a/src/Collector.php
+++ b/src/Collector.php
@@ -107,4 +107,12 @@ final class Collector implements CollectorInterface, JsonSerializable
     {
         return new self(CollectorType::Counter);
     }
+
+    /**
+     * New summary metric.
+     */
+    public static function summary(): self
+    {
+        return new self(CollectorType::Summary);
+    }
 }

--- a/src/CollectorType.php
+++ b/src/CollectorType.php
@@ -9,4 +9,5 @@ enum CollectorType: string
     case Histogram = 'histogram';
     case Gauge = 'gauge';
     case Counter = 'counter';
+    case Summary = 'summary';
 }

--- a/tests/Unit/CollectorTest.php
+++ b/tests/Unit/CollectorTest.php
@@ -74,6 +74,14 @@ final class CollectorTest extends TestCase
         $this->assertSame([], $collector->toArray()['buckets']);
     }
 
+    public function testSummary(): void
+    {
+        $collector = Collector::summary();
+
+        $this->assertSame(CollectorType::Summary, $collector->type);
+        $this->assertSame([], $collector->toArray()['buckets']);
+    }
+
     public function testWithNamespace(): void
     {
         $collector = Collector::counter();


### PR DESCRIPTION
Add summary metric type

```php
$metrics->declare(
    'registered_users',
    Collector::summary()->withHelp('Total registered users counter.')->withLabels('type')
);
```

issue https://github.com/roadrunner-php/issues/issues/21