### PR TITLE
New Feature: Metrics Namespaces

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,7 @@
         <RedundantCastGivenDocblockType errorLevel="suppress" />
         <RedundantCondition errorLevel="suppress" />
         <DocblockTypeContradiction errorLevel="suppress" />
+        <TooManyArguments errorLevel="suppress" />
     </issueHandlers>
     <projectFiles>
         <directory name="src" />

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -19,37 +19,37 @@ class Metrics implements MetricsInterface
         $this->rpc = $rpc->withServicePrefix(self::SERVICE_NAME);
     }
 
-    public function add(string $name, float $value, array $labels = []): void
+    public function add(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
         try {
-            $this->rpc->call('Add', \compact('name', 'value', 'labels'));
+            $this->rpc->call('Add', \compact('name', 'value', 'labels', 'namespace'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
-    public function sub(string $name, float $value, array $labels = []): void
+    public function sub(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
         try {
-            $this->rpc->call('Sub', \compact('name', 'value', 'labels'));
+            $this->rpc->call('Sub', \compact('name', 'value', 'labels', 'namespace'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
-    public function observe(string $name, float $value, array $labels = []): void
+    public function observe(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
         try {
-            $this->rpc->call('Observe', \compact('name', 'value', 'labels'));
+            $this->rpc->call('Observe', \compact('name', 'value', 'labels', 'namespace'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
-    public function set(string $name, float $value, array $labels = []): void
+    public function set(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
         try {
-            $this->rpc->call('Set', \compact('name', 'value', 'labels'));
+            $this->rpc->call('Set', \compact('name', 'value', 'labels', 'namespace'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -72,9 +72,15 @@ class Metrics implements MetricsInterface
         }
     }
 
-    public function unregister(string $name): void
+    public function unregister(string $name, string $namespace = ''): void
     {
+        \assert($name !== '');
+
         try {
+            if ($namespace !== '') {
+                $name = $name . '@' . $namespace;
+            }
+
             $this->rpc->call('Unregister', $name);
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);

--- a/src/RetryMetrics.php
+++ b/src/RetryMetrics.php
@@ -17,24 +17,24 @@ class RetryMetrics implements MetricsInterface
     ) {
     }
 
-    public function add(string $name, float $value, array $labels = []): void
+    public function add(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
-        $this->retry(fn () => $this->metrics->add($name, $value, $labels));
+        $this->retry(fn () => $this->metrics->add($name, $value, $labels, $namespace));
     }
 
-    public function sub(string $name, float $value, array $labels = []): void
+    public function sub(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
-        $this->retry(fn () => $this->metrics->sub($name, $value, $labels));
+        $this->retry(fn () => $this->metrics->sub($name, $value, $labels, $namespace));
     }
 
-    public function observe(string $name, float $value, array $labels = []): void
+    public function observe(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
-        $this->retry(fn () => $this->metrics->observe($name, $value, $labels));
+        $this->retry(fn () => $this->metrics->observe($name, $value, $labels, $namespace));
     }
 
-    public function set(string $name, float $value, array $labels = []): void
+    public function set(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
-        $this->retry(fn () => $this->metrics->set($name, $value, $labels));
+        $this->retry(fn () => $this->metrics->set($name, $value, $labels, $namespace));
     }
 
     public function declare(string $name, CollectorInterface $collector): void
@@ -42,9 +42,9 @@ class RetryMetrics implements MetricsInterface
         $this->retry(fn () => $this->metrics->declare($name, $collector));
     }
 
-    public function unregister(string $name): void
+    public function unregister(string $name, string $namespace = ''): void
     {
-        $this->retry(fn () => $this->metrics->unregister($name));
+        $this->retry(fn () => $this->metrics->unregister($name, $namespace));
     }
 
     private function retry(callable $request): void
@@ -63,7 +63,7 @@ class RetryMetrics implements MetricsInterface
                 }
             }
 
-            usleep($this->retrySleepMicroseconds);
+            \usleep($this->retrySleepMicroseconds);
         } while ($attempts < $this->retryAttempts);
     }
 }

--- a/src/SuppressExceptionsMetrics.php
+++ b/src/SuppressExceptionsMetrics.php
@@ -14,39 +14,39 @@ class SuppressExceptionsMetrics implements MetricsInterface
     ) {
     }
 
-    public function add(string $name, float $value, array $labels = []): void
+    public function add(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
         try {
-            $this->metrics->add($name, $value, $labels);
+            $this->metrics->add($name, $value, $labels, $namespace);
         } catch (MetricsException $e) {
-            $this->logger->warning(sprintf('[Metrics] Operation "Add" was failed: %s', $e->getMessage()));
+            $this->logger->warning(\sprintf('[Metrics] Operation "Add" was failed: %s', $e->getMessage()));
         }
     }
 
-    public function sub(string $name, float $value, array $labels = []): void
+    public function sub(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
         try {
-            $this->metrics->sub($name, $value, $labels);
+            $this->metrics->sub($name, $value, $labels, $namespace);
         } catch (MetricsException $e) {
-            $this->logger->warning(sprintf('[Metrics] Operation "Sub" was failed: %s', $e->getMessage()));
+            $this->logger->warning(\sprintf('[Metrics] Operation "Sub" was failed: %s', $e->getMessage()));
         }
     }
 
-    public function observe(string $name, float $value, array $labels = []): void
+    public function observe(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
         try {
-            $this->metrics->observe($name, $value, $labels);
+            $this->metrics->observe($name, $value, $labels, $namespace);
         } catch (MetricsException $e) {
-            $this->logger->warning(sprintf('[Metrics] Operation "Observe" was failed: %s', $e->getMessage()));
+            $this->logger->warning(\sprintf('[Metrics] Operation "Observe" was failed: %s', $e->getMessage()));
         }
     }
 
-    public function set(string $name, float $value, array $labels = []): void
+    public function set(string $name, float $value, array $labels = [], string $namespace = ''): void
     {
         try {
-            $this->metrics->set($name, $value, $labels);
+            $this->metrics->set($name, $value, $labels, $namespace);
         } catch (MetricsException $e) {
-            $this->logger->warning(sprintf('[Metrics] Operation "Set" was failed: %s', $e->getMessage()));
+            $this->logger->warning(\sprintf('[Metrics] Operation "Set" was failed: %s', $e->getMessage()));
         }
     }
 
@@ -55,16 +55,16 @@ class SuppressExceptionsMetrics implements MetricsInterface
         try {
             $this->metrics->declare($name, $collector);
         } catch (MetricsException $e) {
-            $this->logger->warning(sprintf('[Metrics] Operation "Declare" was failed: %s', $e->getMessage()));
+            $this->logger->warning(\sprintf('[Metrics] Operation "Declare" was failed: %s', $e->getMessage()));
         }
     }
 
-    public function unregister(string $name): void
+    public function unregister(string $name, string $namespace = ''): void
     {
         try {
-            $this->metrics->unregister($name);
+            $this->metrics->unregister($name, $namespace);
         } catch (MetricsException $e) {
-            $this->logger->warning(sprintf('[Metrics] Operation "Unregister" was failed: %s', $e->getMessage()));
+            $this->logger->warning(\sprintf('[Metrics] Operation "Unregister" was failed: %s', $e->getMessage()));
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | ✔️
| Issues        | https://github.com/roadrunner-php/issues/issues/24 , https://github.com/roadrunner-php/issues/issues/23 , https://github.com/roadrunner-server/roadrunner/issues/1745

Now, alongside declaring and publishing your metrics, you can also specify a namespace. This offers a more granular level of organization, helping you group and segregate metrics effectively.

### 🚀 How to use it?

#### 1. Declare a Metric with Namespace

```php
$metrics->declare(
    'http_requests',
    RoadRunner\Metrics\Collector::counter()
        ->withHelp('Collected HTTP requests.')
        ->withLabels('status', 'method')
        ->withNamespace('ns1'),
);
```

#### 2. Publish Metrics to a Specific Namespace

````php
$metrics->add(
    name: 'http_requests',
    value: 1, 
    labels: [$response->getStatusCode(), $req->getMethod(),], 
    namespace: 'ns1'
);
````

````php
$metrics->sub(
    name: 'http_requests',
    value: 1, 
    labels: [$response->getStatusCode(), $req->getMethod(),], 
    namespace: 'ns1'
);
````

````php
$metrics->observe(
    name: 'http_requests',
    value: 1, 
    labels: [$response->getStatusCode(), $req->getMethod(),], 
    namespace: 'ns1'
);
````

````php
$metrics->set(
    name: 'http_requests',
    value: 1, 
    labels: [$response->getStatusCode(), $req->getMethod(),], 
    namespace: 'ns1'
);
````

#### Unregister a Metric with a Specific Namespace

```php
$metrics->unregister('http_requests', 'ns1');
```

---

By offering a namespace capability, you can better structure your metrics, especially in scenarios with multi-tenant applications or varied service divisions. It aids clarity and precision in your metrics collection.

🤝 We hope you find this addition valuable and look forward to your feedback. Happy coding! 🚀