### PR TITLE
feat: Make use of new "Async" RPC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require": {
         "php": ">=8.1",
         "psr/log": ">=2.0",
-        "spiral/goridge": "^4.0",
+        "spiral/goridge": "^4.2",
         "spiral/roadrunner": "^2023.1 || ^2024.1"
     },
     "autoload": {

--- a/src/AbstractMetrics.php
+++ b/src/AbstractMetrics.php
@@ -6,5 +6,8 @@ use Spiral\Goridge\RPC\RPCInterface;
 
 abstract class AbstractMetrics implements MetricsInterface
 {
+	/**
+	 * @var string
+	 */
     protected const SERVICE_NAME = 'metrics';
 }

--- a/src/AbstractMetrics.php
+++ b/src/AbstractMetrics.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spiral\RoadRunner\Metrics;
+
+use Spiral\Goridge\RPC\RPCInterface;
+
+abstract class AbstractMetrics implements MetricsInterface
+{
+    protected const SERVICE_NAME = 'metrics';
+}

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -13,17 +13,15 @@ use function str_contains;
 
 class Metrics extends AbstractMetrics
 {
-    protected readonly RPCInterface $rpc;
-
-    public function __construct(RPCInterface $rpc)
-    {
-        $this->rpc = $rpc->withServicePrefix(self::SERVICE_NAME);
+    public function __construct(
+        protected readonly RPCInterface $rpc
+    ) {
     }
 
     public function add(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->call('Add', compact('name', 'value', 'labels'));
+            $this->rpc->call('metrics.Add', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -32,7 +30,7 @@ class Metrics extends AbstractMetrics
     public function sub(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->call('Sub', compact('name', 'value', 'labels'));
+            $this->rpc->call('metrics.Sub', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -41,7 +39,7 @@ class Metrics extends AbstractMetrics
     public function observe(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->call('Observe', compact('name', 'value', 'labels'));
+            $this->rpc->call('metrics.Observe', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -50,7 +48,7 @@ class Metrics extends AbstractMetrics
     public function set(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->call('Set', compact('name', 'value', 'labels'));
+            $this->rpc->call('metrics.Set', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -59,7 +57,7 @@ class Metrics extends AbstractMetrics
     public function declare(string $name, CollectorInterface $collector): void
     {
         try {
-            $this->rpc->call('Declare', [
+            $this->rpc->call('metrics.Declare', [
                 'name' => $name,
                 'collector' => $collector->toArray(),
             ]);
@@ -76,7 +74,7 @@ class Metrics extends AbstractMetrics
     public function unregister(string $name): void
     {
         try {
-            $this->rpc->call('Unregister', $name);
+            $this->rpc->call('metrics.Unregister', $name);
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -70,7 +70,7 @@ class Metrics implements MetricsInterface
     public function declare(string $name, CollectorInterface $collector): void
     {
         try {
-            $this->wrappedCall('Declare', [
+            $this->rpc->call('Declare', [
                 'name' => $name,
                 'collector' => $collector->toArray(),
             ]);
@@ -87,7 +87,7 @@ class Metrics implements MetricsInterface
     public function unregister(string $name): void
     {
         try {
-            $this->wrappedCall('Unregister', $name);
+            $this->rpc->call('Unregister', $name);
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/MetricsFactory.php
+++ b/src/MetricsFactory.php
@@ -4,6 +4,7 @@ namespace Spiral\RoadRunner\Metrics;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Spiral\Goridge\RPC\AsyncRPCInterface;
 use Spiral\Goridge\RPC\RPCInterface;
 
 class MetricsFactory
@@ -13,8 +14,16 @@ class MetricsFactory
     ) {
     }
 
-    public function create(RPCInterface $rpc, MetricsOptions $options): MetricsInterface
+    public function create(RPCInterface $rpc, MetricsOptions $options = new MetricsOptions()): MetricsInterface
     {
+        if ($options->ignoreResponsesWherePossible && !($rpc instanceof AsyncRPCInterface)) {
+            $this->logger->warning("ignoreResponsesWherePossible is true but no AsyncRPCInterface provided");
+        } elseif (!$options->ignoreResponsesWherePossible && $rpc instanceof AsyncRPCInterface) {
+            $this->logger->warning("ignoreResponsesWherePossible is false but an AsyncRPCInterface was provided");
+        } elseif ($options->ignoreResponsesWherePossible && $rpc instanceof AsyncRPCInterface) {
+            return new MetricsIgnoreResponse($rpc);
+        }
+
         $metrics = new RetryMetrics(
             new Metrics($rpc),
             $options->retryAttempts,
@@ -26,5 +35,14 @@ class MetricsFactory
         }
 
         return $metrics;
+    }
+
+    public static function createMetrics(
+        RPCInterface    $rpc,
+        MetricsOptions  $options = new MetricsOptions(),
+        LoggerInterface $logger = new NullLogger()
+    ): MetricsInterface
+    {
+        return (new self($logger))->create($rpc, $options);
     }
 }

--- a/src/MetricsIgnoreResponse.php
+++ b/src/MetricsIgnoreResponse.php
@@ -8,21 +8,15 @@ use Spiral\RoadRunner\Metrics\Exception\MetricsException;
 
 class MetricsIgnoreResponse extends AbstractMetrics
 {
-    protected readonly AsyncRPCInterface $rpc;
-
-    public function __construct(AsyncRPCInterface $rpc)
-    {
-        /**
-         * @noinspection PhpFieldAssignmentTypeMismatchInspection
-         * @psalm-suppress PropertyTypeCoercion
-         */
-        $this->rpc = $rpc->withServicePrefix(self::SERVICE_NAME);
+    public function __construct(
+        protected readonly AsyncRPCInterface $rpc
+    ) {
     }
 
     public function add(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->callIgnoreResponse('Add', compact('name', 'value', 'labels'));
+            $this->rpc->callIgnoreResponse('metrics.Add', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -31,7 +25,7 @@ class MetricsIgnoreResponse extends AbstractMetrics
     public function sub(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->callIgnoreResponse('Sub', compact('name', 'value', 'labels'));
+            $this->rpc->callIgnoreResponse('metrics.Sub', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -40,7 +34,7 @@ class MetricsIgnoreResponse extends AbstractMetrics
     public function observe(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->callIgnoreResponse('Observe', compact('name', 'value', 'labels'));
+            $this->rpc->callIgnoreResponse('metrics.Observe', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -49,7 +43,7 @@ class MetricsIgnoreResponse extends AbstractMetrics
     public function set(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->callIgnoreResponse('Set', compact('name', 'value', 'labels'));
+            $this->rpc->callIgnoreResponse('metrics.Set', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -58,7 +52,7 @@ class MetricsIgnoreResponse extends AbstractMetrics
     public function declare(string $name, CollectorInterface $collector): void
     {
         try {
-            $this->rpc->call('Declare', [
+            $this->rpc->call('metrics.Declare', [
                 'name' => $name,
                 'collector' => $collector->toArray(),
             ]);
@@ -75,7 +69,7 @@ class MetricsIgnoreResponse extends AbstractMetrics
     public function unregister(string $name): void
     {
         try {
-            $this->rpc->call('Unregister', $name);
+            $this->rpc->call('metrics.Unregister', $name);
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/MetricsIgnoreResponse.php
+++ b/src/MetricsIgnoreResponse.php
@@ -1,29 +1,28 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Spiral\RoadRunner\Metrics;
 
 use Spiral\Goridge\RPC\AsyncRPCInterface;
 use Spiral\Goridge\RPC\Exception\ServiceException;
-use Spiral\Goridge\RPC\RPCInterface;
 use Spiral\RoadRunner\Metrics\Exception\MetricsException;
-use function compact;
-use function str_contains;
 
-class Metrics extends AbstractMetrics
+class MetricsIgnoreResponse extends AbstractMetrics
 {
-    protected readonly RPCInterface $rpc;
+    protected readonly AsyncRPCInterface $rpc;
 
-    public function __construct(RPCInterface $rpc)
+    public function __construct(AsyncRPCInterface $rpc)
     {
+        /**
+         * @noinspection PhpFieldAssignmentTypeMismatchInspection
+         * @psalm-suppress PropertyTypeCoercion
+         */
         $this->rpc = $rpc->withServicePrefix(self::SERVICE_NAME);
     }
 
     public function add(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->call('Add', compact('name', 'value', 'labels'));
+            $this->rpc->callIgnoreResponse('Add', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -32,7 +31,7 @@ class Metrics extends AbstractMetrics
     public function sub(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->call('Sub', compact('name', 'value', 'labels'));
+            $this->rpc->callIgnoreResponse('Sub', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -41,7 +40,7 @@ class Metrics extends AbstractMetrics
     public function observe(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->call('Observe', compact('name', 'value', 'labels'));
+            $this->rpc->callIgnoreResponse('Observe', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }
@@ -50,7 +49,7 @@ class Metrics extends AbstractMetrics
     public function set(string $name, float $value, array $labels = []): void
     {
         try {
-            $this->rpc->call('Set', compact('name', 'value', 'labels'));
+            $this->rpc->callIgnoreResponse('Set', compact('name', 'value', 'labels'));
         } catch (ServiceException $e) {
             throw new MetricsException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/MetricsOptions.php
+++ b/src/MetricsOptions.php
@@ -5,13 +5,16 @@ namespace Spiral\RoadRunner\Metrics;
 class MetricsOptions
 {
     /**
-     * @param int<0, max> $retryAttempts
-     * @param int<0, max> $retrySleepMicroseconds
+     * @param int<0, max> $retryAttempts Number of retry attempts done
+     * @param int<0, max> $retrySleepMicroseconds Amount of microSeconds slept between retry attempts
+     * @param bool $suppressExceptions Whether to suppress the exceptions usually thrown if something went wrong
+     * @param bool $ignoreResponsesWherePossible Whether to use the new callIgnoreResponse RPC interface to speed up Metric collection. May result in lost metrics
      */
     public function __construct(
         public readonly int $retryAttempts = 3,
         public readonly int $retrySleepMicroseconds = 50,
         public readonly bool $suppressExceptions = false,
+        public readonly bool $ignoreResponsesWherePossible = false
     ) {
     }
 }

--- a/tests/Unit/MetricsFactoryTest.php
+++ b/tests/Unit/MetricsFactoryTest.php
@@ -24,9 +24,6 @@ final class MetricsFactoryTest extends TestCase
 
         /** @var MockObject&RPCInterface $rpc */
         $rpc = $this->createMock($rpcInterfaceClass);
-        $rpc->expects($this->once())->method('withServicePrefix')
-            ->with('metrics')
-            ->willReturn($rpc);
 
         self::assertInstanceOf($expectedClass, $factory->create($rpc, $options));
     }
@@ -38,9 +35,6 @@ final class MetricsFactoryTest extends TestCase
     {
         /** @var MockObject&RPCInterface $rpc */
         $rpc = $this->createMock($rpcInterfaceClass);
-        $rpc->expects($this->once())->method('withServicePrefix')
-            ->with('metrics')
-            ->willReturn($rpc);
 
         self::assertInstanceOf($expectedClass, MetricsFactory::createMetrics($rpc, $options));
     }
@@ -52,9 +46,6 @@ final class MetricsFactoryTest extends TestCase
             ->with('ignoreResponsesWherePossible is true but no AsyncRPCInterface provided');
 
         $rpc = $this->createMock(RPCInterface::class);
-        $rpc->expects($this->once())->method('withServicePrefix')
-            ->with('metrics')
-            ->willReturn($rpc);
 
         $factory = new MetricsFactory($logger);
         $factory->create($rpc, new MetricsOptions(ignoreResponsesWherePossible: true));
@@ -67,9 +58,6 @@ final class MetricsFactoryTest extends TestCase
             ->with('ignoreResponsesWherePossible is false but an AsyncRPCInterface was provided');
 
         $rpc = $this->createMock(AsyncRPCInterface::class);
-        $rpc->expects($this->once())->method('withServicePrefix')
-            ->with('metrics')
-            ->willReturn($rpc);
 
         $factory = new MetricsFactory($logger);
         $factory->create($rpc, new MetricsOptions(ignoreResponsesWherePossible: false));

--- a/tests/Unit/MetricsFactoryTest.php
+++ b/tests/Unit/MetricsFactoryTest.php
@@ -99,10 +99,20 @@ final class MetricsFactoryTest extends TestCase
                 'rpcInterfaceClass' => RPCInterface::class
             ],
             'create MetricsIgnoreResponse if AsyncRPCInterface' => [
-                'options' => new MetricsOptions(ignoreResponsesWherePossible: true),
+                'options' => new MetricsOptions(retryAttempts: 0, suppressExceptions: false, ignoreResponsesWherePossible: true),
                 'expectedClass' => MetricsIgnoreResponse::class,
                 'rpcInterfaceClass' => AsyncRPCInterface::class
-            ]
+            ],
+            'create MetricsIgnoreResponse with RetryMetrics if AsyncRPCInterface' => [
+                'options' => new MetricsOptions(retryAttempts: 3, suppressExceptions: false, ignoreResponsesWherePossible: true),
+                'expectedClass' => RetryMetrics::class,
+                'rpcInterfaceClass' => AsyncRPCInterface::class
+            ],
+            'create MetricsIgnoreResponse with SuppressExceptions if AsyncRPCInterface' => [
+                'options' => new MetricsOptions(retryAttempts: 3, suppressExceptions: true, ignoreResponsesWherePossible: true),
+                'expectedClass' => SuppressExceptionsMetrics::class,
+                'rpcInterfaceClass' => AsyncRPCInterface::class
+            ],
         ];
     }
 }

--- a/tests/Unit/MetricsFactoryTest.php
+++ b/tests/Unit/MetricsFactoryTest.php
@@ -2,10 +2,13 @@
 
 namespace Spiral\RoadRunner\Metrics\Tests\Unit;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Spiral\Goridge\RPC\RPC;
+use Psr\Log\LoggerInterface;
+use Spiral\Goridge\RPC\AsyncRPCInterface;
 use Spiral\Goridge\RPC\RPCInterface;
 use Spiral\RoadRunner\Metrics\MetricsFactory;
+use Spiral\RoadRunner\Metrics\MetricsIgnoreResponse;
 use Spiral\RoadRunner\Metrics\MetricsOptions;
 use Spiral\RoadRunner\Metrics\RetryMetrics;
 use Spiral\RoadRunner\Metrics\SuppressExceptionsMetrics;
@@ -15,16 +18,61 @@ final class MetricsFactoryTest extends TestCase
     /**
      * @dataProvider providerForTestCreate
      */
-    public function testCreate(MetricsOptions $options, string $expectedClass): void
+    public function testCreate(MetricsOptions $options, string $expectedClass, string $rpcInterfaceClass): void
     {
         $factory = new MetricsFactory();
+
+        /** @var MockObject&RPCInterface $rpc */
+        $rpc = $this->createMock($rpcInterfaceClass);
+        $rpc->expects($this->once())->method('withServicePrefix')
+            ->with('metrics')
+            ->willReturn($rpc);
+
+        self::assertInstanceOf($expectedClass, $factory->create($rpc, $options));
+    }
+
+    /**
+     * @dataProvider providerForTestCreate
+     */
+    public function testCreateStatic(MetricsOptions $options, string $expectedClass, string $rpcInterfaceClass): void
+    {
+        /** @var MockObject&RPCInterface $rpc */
+        $rpc = $this->createMock($rpcInterfaceClass);
+        $rpc->expects($this->once())->method('withServicePrefix')
+            ->with('metrics')
+            ->willReturn($rpc);
+
+        self::assertInstanceOf($expectedClass, MetricsFactory::createMetrics($rpc, $options));
+    }
+
+    public function testLogsIfIgnoreResponseButNoAsyncRPCInterface(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning')
+            ->with('ignoreResponsesWherePossible is true but no AsyncRPCInterface provided');
 
         $rpc = $this->createMock(RPCInterface::class);
         $rpc->expects($this->once())->method('withServicePrefix')
             ->with('metrics')
             ->willReturn($rpc);
 
-        self::assertInstanceOf($expectedClass, $factory->create($rpc, $options));
+        $factory = new MetricsFactory($logger);
+        $factory->create($rpc, new MetricsOptions(ignoreResponsesWherePossible: true));
+    }
+
+    public function testLogsIfAsyncRPCInterfaceButNoIgnoreResponses(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning')
+            ->with('ignoreResponsesWherePossible is false but an AsyncRPCInterface was provided');
+
+        $rpc = $this->createMock(AsyncRPCInterface::class);
+        $rpc->expects($this->once())->method('withServicePrefix')
+            ->with('metrics')
+            ->willReturn($rpc);
+
+        $factory = new MetricsFactory($logger);
+        $factory->create($rpc, new MetricsOptions(ignoreResponsesWherePossible: false));
     }
 
     public static function providerForTestCreate(): array
@@ -33,11 +81,28 @@ final class MetricsFactoryTest extends TestCase
             'create RetryMetrics' => [
                 'options' => new MetricsOptions(),
                 'expectedClass' => RetryMetrics::class,
+                'rpcInterfaceClass' => RPCInterface::class
             ],
             'create SuppressExceptionsMetrics' => [
                 'options' => new MetricsOptions(suppressExceptions: true),
                 'expectedClass' => SuppressExceptionsMetrics::class,
+                'rpcInterfaceClass' => RPCInterface::class
             ],
+            'create Metrics if no AsyncRPCInterface' => [
+                'options' => new MetricsOptions(ignoreResponsesWherePossible: true),
+                'expectedClass' => RetryMetrics::class,
+                'rpcInterfaceClass' => RPCInterface::class
+            ],
+            'create Metrics if AsyncRPCInterface but ignoreResponse... false' => [
+                'options' => new MetricsOptions(ignoreResponsesWherePossible: false),
+                'expectedClass' => RetryMetrics::class,
+                'rpcInterfaceClass' => RPCInterface::class
+            ],
+            'create MetricsIgnoreResponse if AsyncRPCInterface' => [
+                'options' => new MetricsOptions(ignoreResponsesWherePossible: true),
+                'expectedClass' => MetricsIgnoreResponse::class,
+                'rpcInterfaceClass' => AsyncRPCInterface::class
+            ]
         ];
     }
 }

--- a/tests/Unit/MetricsIgnoreResponseTest.php
+++ b/tests/Unit/MetricsIgnoreResponseTest.php
@@ -22,10 +22,6 @@ final class MetricsIgnoreResponseTest extends TestCase
         parent::setUp();
 
         $this->rpc = $this->createMock(AsyncRPCInterface::class);
-        $this->rpc->expects($this->once())->method('withServicePrefix')
-            ->with('metrics')
-            ->willReturn($this->rpc);
-
         $this->metrics = new MetricsIgnoreResponse($this->rpc);
     }
 
@@ -33,7 +29,7 @@ final class MetricsIgnoreResponseTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('callIgnoreResponse')
-            ->with('Add', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
+            ->with('metrics.Add', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
 
         $this->metrics->add('foo', 1.0, ['bar', 'baz']);
     }
@@ -42,7 +38,7 @@ final class MetricsIgnoreResponseTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('callIgnoreResponse')
-            ->with('Sub', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
+            ->with('metrics.Sub', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
 
         $this->metrics->sub('foo', 1.0, ['bar', 'baz']);
     }
@@ -51,7 +47,7 @@ final class MetricsIgnoreResponseTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('callIgnoreResponse')
-            ->with('Observe', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
+            ->with('metrics.Observe', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
 
         $this->metrics->observe('foo', 1.0, ['bar', 'baz']);
     }
@@ -60,7 +56,7 @@ final class MetricsIgnoreResponseTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('callIgnoreResponse')
-            ->with('Set', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
+            ->with('metrics.Set', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
 
         $this->metrics->set('foo', 1.0, ['bar', 'baz']);
     }
@@ -74,7 +70,7 @@ final class MetricsIgnoreResponseTest extends TestCase
 
         $this->rpc->expects($this->once())
             ->method('call')
-            ->with('Declare', ['name' => 'foo', 'collector' => $payload])
+            ->with('metrics.Declare', ['name' => 'foo', 'collector' => $payload])
             ->willReturn(null);
 
         $this->metrics->declare('foo', $collector);
@@ -116,7 +112,7 @@ final class MetricsIgnoreResponseTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('call')
-            ->with('Unregister', 'foo')
+            ->with('metrics.Unregister', 'foo')
             ->willReturn(null);
 
         $this->metrics->unregister('foo');

--- a/tests/Unit/MetricsIgnoreResponseTest.php
+++ b/tests/Unit/MetricsIgnoreResponseTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Goridge\RPC\AsyncRPCInterface;
+use Spiral\Goridge\RPC\Exception\ServiceException;
+use Spiral\Goridge\RPC\RPCInterface;
+use Spiral\RoadRunner\Metrics\CollectorInterface;
+use Spiral\RoadRunner\Metrics\Exception\MetricsException;
+use Spiral\RoadRunner\Metrics\Metrics;
+use Spiral\RoadRunner\Metrics\MetricsIgnoreResponse;
+
+final class MetricsIgnoreResponseTest extends TestCase
+{
+    private MetricsIgnoreResponse $metrics;
+    private \PHPUnit\Framework\MockObject\MockObject&AsyncRPCInterface $rpc;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rpc = $this->createMock(AsyncRPCInterface::class);
+        $this->rpc->expects($this->once())->method('withServicePrefix')
+            ->with('metrics')
+            ->willReturn($this->rpc);
+
+        $this->metrics = new MetricsIgnoreResponse($this->rpc);
+    }
+
+    public function testAdd(): void
+    {
+        $this->rpc->expects($this->once())
+            ->method('callIgnoreResponse')
+            ->with('Add', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
+
+        $this->metrics->add('foo', 1.0, ['bar', 'baz']);
+    }
+
+    public function testSub(): void
+    {
+        $this->rpc->expects($this->once())
+            ->method('callIgnoreResponse')
+            ->with('Sub', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
+
+        $this->metrics->sub('foo', 1.0, ['bar', 'baz']);
+    }
+
+    public function testObserve(): void
+    {
+        $this->rpc->expects($this->once())
+            ->method('callIgnoreResponse')
+            ->with('Observe', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
+
+        $this->metrics->observe('foo', 1.0, ['bar', 'baz']);
+    }
+
+    public function testSet(): void
+    {
+        $this->rpc->expects($this->once())
+            ->method('callIgnoreResponse')
+            ->with('Set', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']]);
+
+        $this->metrics->set('foo', 1.0, ['bar', 'baz']);
+    }
+
+    public function testDeclare(): void
+    {
+        $collector = $this->createMock(CollectorInterface::class);
+        $collector->expects($this->once())
+            ->method('toArray')
+            ->willReturn($payload = ['foo' => 'bar']);
+
+        $this->rpc->expects($this->once())
+            ->method('call')
+            ->with('Declare', ['name' => 'foo', 'collector' => $payload])
+            ->willReturn(null);
+
+        $this->metrics->declare('foo', $collector);
+    }
+
+    public function testDeclareWithError(): void
+    {
+        $collector = $this->createMock(CollectorInterface::class);
+        $collector->method('toArray')->willReturn(['foo' => 'bar']);
+
+        $e = new ServiceException('Something went wrong', 1);
+
+        $this->expectException(MetricsException::class);
+        $this->expectExceptionMessage($e->getMessage());
+        $this->expectExceptionCode($e->getCode());
+
+        $this->rpc->expects($this->once())
+            ->method('call')
+            ->willThrowException($e);
+
+        $this->metrics->declare('foo', $collector);
+    }
+
+    public function testDeclareWithSuppressedError(): void
+    {
+        $collector = $this->createMock(CollectorInterface::class);
+        $collector->method('toArray')->willReturn(['foo' => 'bar']);
+
+        $e = new ServiceException('Something tried to register existing collector.', 1);
+
+        $this->rpc->expects($this->once())
+            ->method('call')
+            ->willThrowException($e);
+
+        $this->metrics->declare('foo', $collector);
+    }
+
+    public function testUnregister(): void
+    {
+        $this->rpc->expects($this->once())
+            ->method('call')
+            ->with('Unregister', 'foo')
+            ->willReturn(null);
+
+        $this->metrics->unregister('foo');
+    }
+
+    public function testUnregisterWithError(): void
+    {
+        $e = new ServiceException('Something went wrong', 1);
+
+        $this->expectException(MetricsException::class);
+        $this->expectExceptionMessage($e->getMessage());
+        $this->expectExceptionCode($e->getCode());
+
+        $this->rpc->expects($this->once())
+            ->method('call')
+            ->willThrowException($e);
+
+        $this->metrics->unregister('foo');
+    }
+}

--- a/tests/Unit/MetricsTest.php
+++ b/tests/Unit/MetricsTest.php
@@ -21,10 +21,6 @@ final class MetricsTest extends TestCase
         parent::setUp();
 
         $this->rpc = $this->createMock(RPCInterface::class);
-        $this->rpc->expects($this->once())->method('withServicePrefix')
-            ->with('metrics')
-            ->willReturn($this->rpc);
-
         $this->metrics = new Metrics($this->rpc);
     }
 
@@ -32,7 +28,7 @@ final class MetricsTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('call')
-            ->with('Add', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']])
+            ->with('metrics.Add', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']])
             ->willReturn(null);
 
         $this->metrics->add('foo', 1.0, ['bar', 'baz']);
@@ -57,7 +53,7 @@ final class MetricsTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('call')
-            ->with('Sub', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']])
+            ->with('metrics.Sub', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']])
             ->willReturn(null);
 
         $this->metrics->sub('foo', 1.0, ['bar', 'baz']);
@@ -82,7 +78,7 @@ final class MetricsTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('call')
-            ->with('Observe', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']])
+            ->with('metrics.Observe', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']])
             ->willReturn(null);
 
         $this->metrics->observe('foo', 1.0, ['bar', 'baz']);
@@ -107,7 +103,7 @@ final class MetricsTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('call')
-            ->with('Set', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']])
+            ->with('metrics.Set', ['name' => 'foo', 'value' => 1.0, 'labels' => ['bar', 'baz']])
             ->willReturn(null);
 
         $this->metrics->set('foo', 1.0, ['bar', 'baz']);
@@ -137,7 +133,7 @@ final class MetricsTest extends TestCase
 
         $this->rpc->expects($this->once())
             ->method('call')
-            ->with('Declare', ['name' => 'foo', 'collector' => $payload])
+            ->with('metrics.Declare', ['name' => 'foo', 'collector' => $payload])
             ->willReturn(null);
 
         $this->metrics->declare('foo', $collector);
@@ -179,7 +175,7 @@ final class MetricsTest extends TestCase
     {
         $this->rpc->expects($this->once())
             ->method('call')
-            ->with('Unregister', 'foo')
+            ->with('metrics.Unregister', 'foo')
             ->willReturn(null);
 
         $this->metrics->unregister('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️ TODO: please update "Other Features" section in CHANGELOG.md file
| Issues        | https://github.com/roadrunner-php/goridge/pull/22 
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

This is a follow-up PR for https://github.com/roadrunner-php/goridge/pull/22 implementing the new "async" RPC calls in the Metrics class.
~It may be an option to instead modify the `MetricsFactory` to return an `AsyncMetrics` class instead if it detects an async RPC interface, or something like that. Please lmk if you'd like me to change that. Once the implementation is good to go I'll add tests for it as well.~

EDIT: I've switched to the `MetricsFactory` because implementing it into our service was kinda weird otherwise. I've also added a few tests and fixed the Psalm complaint.

For further info please read the linked PR in the goridge repo.

Same PR in the KV repo: https://github.com/roadrunner-php/kv/pull/36


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `AbstractMetrics` class for structured metrics functionality.
	- Added `MetricsIgnoreResponse` class to handle metrics operations while ignoring RPC responses.
	- Enhanced `MetricsOptions` for improved configurability during metric collection.

- **Improvements**
	- Updated `Metrics` class to streamline method calls and enhance error handling.
	- Modified `MetricsFactory` to support flexible metrics creation with new options.

- **Tests**
	- Expanded test coverage for `MetricsFactory` and `MetricsIgnoreResponse` classes to ensure robust functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->